### PR TITLE
[codex] Fix npm OIDC publishing workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -15,13 +15,14 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: npm-publishing
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
       - name: Setup pnpm
@@ -36,6 +37,5 @@ jobs:
       - name: Publish to npm (with provenance)
         run: |
           cd dist
-          pnpm publish --provenance --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.THE_PROMPTING_COMPANY_NPM_TOKEN || secrets.NPM_TOKEN }}
+          tag=$(node -p 'const version = require("./package.json").version; const match = version.match(/-([0-9A-Za-z]+)(?:[.-]|$)/); match ? match[1] : "latest"')
+          npm publish --provenance --access public --tag "$tag"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
   "type": "commonjs",
-  "repository": "github:promptingcompany/sdk-typescript",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/promptingcompany/sdk-typescript.git"
+  },
   "license": "Apache-2.0",
   "packageManager": "pnpm@10.30.1",
   "files": [


### PR DESCRIPTION
## Summary

- Updates the npm publish workflow to use the GitHub environment `npm-publishing` so the OIDC token and any environment-scoped secrets line up with the configured release environment.
- Switches the publish runtime to Node 24 and `npm publish`, which is the supported npm Trusted Publishing path for OIDC.
- Computes the dist-tag from prerelease versions so alpha releases publish with `--tag alpha` instead of failing npm's prerelease tag requirement.
- Expands the package repository metadata to the explicit GitHub URL npm expects for trusted publishing checks.

## Root Cause

The previous workflow declared `id-token: write`, but it still ran Node 20/npm 10 and published through `pnpm publish` while passing an empty token fallback. npm therefore fell back to token auth and failed with `ENEEDAUTH`. The job also did not declare the `npm-publishing` environment, so an npm trusted-publisher configuration that includes that environment would not match.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `npm publish --dry-run --provenance --access public --tag alpha` from `dist`

The live OIDC exchange still has to run inside GitHub Actions against the npm package's Trusted Publisher configuration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes npm Trusted Publishing via OIDC by updating the publish workflow and package metadata so releases publish reliably, including prerelease tags.

- **Bug Fixes**
  - Align OIDC with GitHub environment `npm-publishing` and set the `repository` to the explicit GitHub URL npm expects.
  - Use Node 24 and `npm publish` with provenance; remove token-based auth fallback.
  - Auto-derive the dist-tag from prerelease versions (e.g., `alpha`), defaulting to `latest`.

<sup>Written for commit a9e7ae4e881e8c99751f82267f5c0dcf80f69c4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

