### PR TITLE
feat(document): add list() method for site pages via Stainless

### DIFF
--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -35,6 +35,7 @@ resources:
     methods:
       get: get /api/v1/md/{id}
       get_by_path: get /api/v1/md/by-path/{path}
+      list: get /api/v1/site/pages
 
 settings:
   # All generated integration tests that hit the prism mock http server are marked


### PR DESCRIPTION
## Summary

Adds `client.document.list()` so callers can paginate and filter organization-scoped site pages (the source of the public markdown documents).

### Config change
- Added `list: get /api/v1/site/pages` in `.stainless/stainless.yml`

### Generated API (new)

```ts
const result = await client.document.list({
  productId: 'prod_xxx',           // required
  page: 1,
  pageSize: 20,
  query: 'getting started',
  pathPrefix: '/docs',
  status: 'published',
  isManual: true,
  archivedStatus: 'active',
  orderBy: 'updatedAt',
  orderByDirection: 'desc',
  // + all other filters from the OpenAPI spec
});

console.log(result.data.total, result.data.totalPages);

for (const page of result.data.items) {
  console.log(page.id, page.filePath, page.title, page.status);
  // page also has: domains[], metaTitle, metaDescription, publishedAt, etc.
}
```

The response is a proper paginated list with scope (product + organization) information.

### Stainless build
- **Build ID**: `bui_0cmp70lvkh000625s6e0l1gk74`
- Generated diff: **+205 / -5 lines**
- All CI checks passed (Lint ✅, Tests ✅, Build ✅)
- Pushed to `stainless-sdks/tpc-typescript` on `next`

This PR brings in the config change. The corresponding generated SDK code is available from the Stainless build.

### Checklist
- [x] Stainless config updated
- [x] Build succeeded with clean CI
- [ ] Review generated types in the PR diff (or from the mirror)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `client.document.list()` to fetch organization-scoped site pages from `/api/v1/site/pages` with pagination and filtering. This lets clients list product docs (public markdown sources) with standard sorting and filters.

- **New Features**
  - Mapped `document.list` to `GET /api/v1/site/pages` in `.stainless/stainless.yml`.
  - Requires `productId`; supports `page`, `pageSize`, `query`, `pathPrefix`, `status`, `isManual`, `archivedStatus`, `orderBy`, `orderByDirection`, and other documented filters.
  - Returns a paginated response with totals and items including page metadata (`id`, `filePath`, `title`, `status`, etc.).

<sup>Written for commit b77f0afe19595fc4a0a3d0fbb931ba73b092c781. Summary will update on new commits. <a href="https://cubic.dev/pr/promptingcompany/sdk-typescript/pull/17?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

