### PR TITLE
chore(release): enable stable v0.1.0 releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,7 @@
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "versioning": "prerelease",
-  "prerelease": true,
+  "prerelease": false,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
   "pull-request-header": "Automated Release PR",


### PR DESCRIPTION
## Summary

Disables prerelease mode in Release Please so the SDK can graduate from `0.0.0-alpha.x` to the first stable `v0.1.0` release.

### Changes
- Set `"prerelease": false` in `release-please-config.json` (both root and generated copy)

### Effect
After this is merged, the next Release Please run will propose `v0.1.0` (instead of another alpha) as the next version.

This is the final step needed before we can cut the first stable release.

### Related
- Builds on the recent `document.list()` feature (PR #17)
- Prepares the repo for proper semver releases going forward

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turn off prerelease mode in `release-please` (`prerelease: false` in `release-please-config.json`). The next release will be v0.1.0 instead of another 0.0.0-alpha.x.

<sup>Written for commit 5790ddffbadb6a53ae11f593b05a985f1d987c13. Summary will update on new commits. <a href="https://cubic.dev/pr/promptingcompany/sdk-typescript/pull/18?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

