### PR TITLE
fix(ci): make npm publish workflow idempotent for already-published versions

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -37,5 +37,10 @@ jobs:
       - name: Publish to npm (with provenance)
         run: |
           cd dist
+          VERSION=$(node -p 'require("./package.json").version')
+          if npm view "@promptingcompany/sdk@${VERSION}" version >/dev/null 2>&1; then
+            echo "Version ${VERSION} is already published on npm — skipping (workflow is safe to re-run)."
+            exit 0
+          fi
           tag=$(node -p 'const version = require("./package.json").version; const match = version.match(/-([0-9A-Za-z]+)(?:[.-]|$)/); match ? match[1] : "latest"')
           npm publish --provenance --access public --tag "$tag"

--- a/bin/publish-npm
+++ b/bin/publish-npm
@@ -26,5 +26,10 @@ else
   TAG="latest"
 fi
 
+if npm view "@promptingcompany/sdk@${VERSION}" version >/dev/null 2>&1; then
+  echo "==> Version ${VERSION} is already published on npm — skipping."
+  exit 0
+fi
+
 echo "==> Publishing @promptingcompany/sdk@$VERSION with tag '$TAG'..."
 pnpm publish --no-git-checks --tag "$TAG"


### PR DESCRIPTION
## Summary
The `Publish NPM` workflow (and `bin/publish-npm`) now gracefully skips instead of failing when the target version is already present on npmjs.

This fixes the exact class of failure we saw with **v0.2.0**:

```
npm error 400 Bad Request ... Cannot publish over previously published version "0.2.0"
```

even though `0.2.0` was **never actually published** (no tarball, 404 on the version endpoint, `dist-tags.latest` remained `0.1.1`).

### Root cause
- A provenance-enabled `npm publish` (or a race with Stainless's `publish: { npm: true }` path) can leave a version metadata entry in the registry even when the full publish fails partway through.
- The workflow had no guard, so any re-run, manual `workflow_dispatch`, or concurrent publish would turn the job red with E400.
- We had recently migrated to OIDC + provenance (`environment: npm-publishing`), which made these partial failures more visible.

### Changes
- `.github/workflows/publish-npm.yml`: before publishing, run `npm view "@promptingcompany/sdk@${VERSION}" version`. If it succeeds we print a clear skip message and exit 0.
- `bin/publish-npm`: same guard for local / emergency publishes.

The job is now safe to re-run from the Actions UI for any release.

### Testing
- Verified locally that the check correctly detects already-published versions (0.1.1) and proceeds for new ones.
- The change is minimal and only affects the publish path.

## Related
- Addresses the v0.2.0 publish failure in the 2026-05-15 run.
- Complements the earlier OIDC/provenance migration and the switch to `production_repo: promptingcompany/sdk-typescript`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `Publish NPM` workflow and `bin/publish-npm` idempotent by skipping when the target version of `@promptingcompany/sdk` is already on npm. Adds a lightweight npm view pre-check to avoid E400 "Cannot publish over previously published version" and make re-runs safe, including after partial provenance publishes.

<sup>Written for commit 939b221164d3a31c9e12cdef54f0f59e1e5b6302. Summary will update on new commits. <a href="https://cubic.dev/pr/promptingcompany/sdk-typescript/pull/25?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

