### PR TITLE
chore: remove organizationAPIKey in favor of single apiKey

### DIFF
--- a/.stainless/stainless.yml
+++ b/.stainless/stainless.yml
@@ -53,43 +53,39 @@ client_settings:
     api_key:
       type: string
       nullable: false
-      description: Simple API key (tpc_...) sent as Bearer token in Authorization header for public document access
+      description: API key (tpc_...) used for authentication. Sent via Authorization header for public document endpoints and via x-api-key header for organization-scoped endpoints.
       read_env: TPC_API_KEY
       send_in_header: Authorization
+      auth:
+        security_scheme: apiKeyAuth
+
     organization_id:
       type: string
       nullable: true
       description: Organization ID sent as X-Tpc-Organization-Id header
       read_env: TPC_ORGANIZATION_ID
       send_in_header: 'X-Tpc-Organization-Id'
+
     organization_slug:
       type: string
       nullable: true
       description: Organization slug sent as X-Tpc-Organization-Slug header
       read_env: TPC_ORGANIZATION_SLUG
       send_in_header: 'X-Tpc-Organization-Slug'
+
     product_id:
       type: string
       nullable: true
       description: Product ID sent as X-Tpc-Product-Id header
       read_env: TPC_PRODUCT_ID
       send_in_header: 'X-Tpc-Product-Id'
+
     product_slug:
       type: string
       nullable: true
       description: Product slug sent as X-Tpc-Product-Slug header
       read_env: TPC_PRODUCT_SLUG
       send_in_header: 'X-Tpc-Product-Slug'
-
-    # Internal / authenticated API keys (wired to OpenAPI securitySchemes to silence lint warnings)
-    organization_api_key:
-      type: string
-      nullable: true
-      auth:
-        security_scheme: apiKeyAuth
-      description: Organization-scoped API key (x-api-key header) for authenticated internal API access
-      read_env: TPC_ORGANIZATION_API_KEY
-      send_in_header: X-Api-Key
 
     bearer_token:
       type: string


### PR DESCRIPTION
## Summary

This PR removes the `organizationAPIKey` option from the SDK in favor of a single `apiKey` field.

### Breaking Change

- The `organizationAPIKey` constructor option and environment variable (`TPC_ORGANIZATION_API_KEY`) have been removed.
- Users should now use the single `apiKey` field (`TPC_API_KEY`) for all authentication needs.
- The `apiKey` value will automatically be sent as the appropriate header (`Authorization` or `x-api-key`) based on the endpoint's security requirements.

### Motivation

Previously, the SDK exposed two separate API key options:
- `apiKey` → sent as `Authorization`
- `organizationAPIKey` → sent as `x-api-key`

This distinction was not clearly documented on the public API site and added unnecessary complexity for users. Most users only have one API key and expect it to "just work".

### Migration

Before:
```ts
const client = new ThePromptingCompany({
  apiKey: 'tpc_xxx',
  organizationAPIKey: 'org_xxx'
});
```

After:
```ts
const client = new ThePromptingCompany({
  apiKey: 'tpc_xxx'   // works for both public and organization-scoped endpoints
});
```

### Notes

- `bearerToken` and `sessionToken` remain available for other authentication methods.
- Organization and product scoping headers (`organizationID`, `organizationSlug`, `productID`, `productSlug`) are unchanged.

This change is intended to ship as part of the v0.1.1 release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `organizationAPIKey` in favor of a single `apiKey` for all SDK authentication. Breaking change: use `TPC_API_KEY` only; the SDK now sends it as `Authorization` or `x-api-key` automatically based on the endpoint.

- **Migration**
  - Remove the `organizationAPIKey` option and `TPC_ORGANIZATION_API_KEY`.
  - Set only `apiKey` (or `TPC_API_KEY`) in your config/env.
  - No changes to `bearerToken`, `sessionToken`, or organization/product scoping headers.

<sup>Written for commit 72f3ca945645cc5a18bfdca1449a90d39dbb4afc. Summary will update on new commits. <a href="https://cubic.dev/pr/promptingcompany/sdk-typescript/pull/28?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

